### PR TITLE
Fix  #48 - syntax error in scores

### DIFF
--- a/1954--switzerland/cup.txt
+++ b/1954--switzerland/cup.txt
@@ -18,7 +18,7 @@ Group 1:
 (3)  16 June    Brazil       5-0   Mexico    @ Charmilles Stadium, Geneva
 (4)  16 June    Yugoslavia   1-0   France    @ Stade Olympique de la Pontaise, Lausanne
 
-(10) 19 June    Brazil     1-1 a.e.t. 1-1  Yugoslavia  @ Stade Olympique de la Pontaise, Lausanne
+(10) 19 June    Brazil     1-1 a.e.t. (1-1)  Yugoslavia  @ Stade Olympique de la Pontaise, Lausanne
 (11) 19 June    France     3-2             Mexico      @ Charmilles Stadium, Geneva
 
 
@@ -49,7 +49,7 @@ Group 3:
 
 Group 4:
 
-(6)  17 June    England          4-4 a.e.t. 3-3  Belgium    @ St. Jakob Stadium, Basel
+(6)  17 June    England          4-4 a.e.t. (3-3)  Belgium    @ St. Jakob Stadium, Basel
 (7)  17 June    Switzerland      2-1  Italy                 @ Stade Olympique de la Pontaise, Lausanne
 
 (13) 20 June    England          2-0  Switzerland     @ Wankdorf Stadium, Bern
@@ -75,7 +75,7 @@ Quarter-finals
 Semi-finals
 
 (21) 30 June    West Germany     6-1         Austria        @ St. Jakob Stadium, Basel
-(22) 30 June    Hungary      4-2 a.e.t. 2-2  Uruguay        @ Stade Olympique de la Pontaise, Lausanne
+(22) 30 June    Hungary      4-2 a.e.t. (2-2)  Uruguay        @ Stade Olympique de la Pontaise, Lausanne
 
 
 Third-place match         ## use just Third-place  - why? why not?

--- a/1966--england/cup.txt
+++ b/1966--england/cup.txt
@@ -80,5 +80,5 @@ Third-place match
 
 Final
 
-(32) 30 July    England   4-2 a.e.t. 2-2   West Germany  @ Wembley Stadium, London
+(32) 30 July    England   4-2 a.e.t. (2-2)   West Germany  @ Wembley Stadium, London
 

--- a/1970--mexico/cup.txt
+++ b/1970--mexico/cup.txt
@@ -60,16 +60,16 @@ Group 4:
 
 Quarter-finals
 
-(25) 14 June    Soviet Union  0-1 a.e.t. 0-0   Uruguay    @ Estadio Azteca, Mexico City
+(25) 14 June    Soviet Union  0-1 a.e.t. (0-0)   Uruguay    @ Estadio Azteca, Mexico City
 (26) 14 June    Italy         4-1              Mexico     @ Estadio Luis Dosal, Toluca
 (27) 14 June    Brazil        4-2              Peru       @ Estadio Jalisco, Guadalajara
-(28) 14 June    West Germany  3-2 a.e.t. 2-2   England    @ Estadio Nou Camp, León
+(28) 14 June    West Germany  3-2 a.e.t. (2-2)   England    @ Estadio Nou Camp, León
 
 
 Semi-finals
 
 (29) 17 June    Uruguay    1-3               Brazil        @ Estadio Jalisco, Guadalajara
-(30) 17 June    Italy      4-3 a.e.t. 1-1    West Germany  @ Estadio Azteca, Mexico City
+(30) 17 June    Italy      4-3 a.e.t. (1-1)    West Germany  @ Estadio Azteca, Mexico City
 
 Match for third place
 

--- a/1978--argentina/cup.txt
+++ b/1978--argentina/cup.txt
@@ -102,5 +102,5 @@ Third place match
 
 Final
 
-(38) 25 June   Netherlands    1-3 a.e.t. 1-1   Argentina   @ Estadio Monumental, Buenos Aires
+(38) 25 June   Netherlands    1-3 a.e.t. (1-1)   Argentina   @ Estadio Monumental, Buenos Aires
 

--- a/1982--spain/cup.txt
+++ b/1982--spain/cup.txt
@@ -133,7 +133,7 @@ Group D:
 Semi-finals
 
 (49) 8 July    Poland        0-2    Italy   @ Camp Nou, Barcelona
-(50) 8 July    West Germany  5-4pen 3-3aet 1-1  France  @ Estadio Ramón Sánchez Pizjuán, Seville
+(50) 8 July    West Germany  5-4pen 3-3aet (1-1)  France  @ Estadio Ramón Sánchez Pizjuán, Seville
 
 
 Third place match

--- a/1994--united-states/cup.txt
+++ b/1994--united-states/cup.txt
@@ -12,7 +12,7 @@ Group F  |  Netherlands  Saudi Arabia   Belgium          Morocco
 ## todo/fix:  use more matchdays - one matchday per "real" day !!!
 ##   26 June is played 2nd and 3rd games
 
-Matchday 1 | 18 June - 21 June
+Matchday 1 | 17 June - 21 June
 Matchday 2 | 22 June - 26 June
 Matchday 3 | 27 June - 30 June
 

--- a/1994--united-states/cup_finals.txt
+++ b/1994--united-states/cup_finals.txt
@@ -14,8 +14,8 @@ Round of 16
 (41)  4 July   Netherlands   2-0    Ireland        @ Citrus Bowl, Orlando
 (42)  4 July   Brazil        1-0    United States  @ Stanford Stadium, Stanford
 
-(43)  5 July   Nigeria    1-2 a.e.t. 1-1    Italy  @ Foxboro Stadium, Foxborough
-(44)  5 July   Mexico  1-3pen 1-1 a.e.t. 1-1    Bulgaria  @ Giants Stadium, East Rutherford
+(43)  5 July   Nigeria    1-2 a.e.t. (1-1)    Italy  @ Foxboro Stadium, Foxborough
+(44)  5 July   Mexico  1-3pen 1-1 a.e.t. (1-1)    Bulgaria  @ Giants Stadium, East Rutherford
 
 
 Quarter-finals
@@ -24,7 +24,7 @@ Quarter-finals
 (46)  9 July   Netherlands   2-3    Brazil   @ Cotton Bowl, Dallas
 
 (47) 10 July  Bulgaria      2-1    Germany   @ Giants Stadium, East Rutherford
-(48) 10 July  Romania    4-5pen 2-2aet 1-1   Sweden  @ Stanford Stadium, Stanford
+(48) 10 July  Romania    4-5pen 2-2aet (1-1)   Sweden  @ Stanford Stadium, Stanford
 
 
 Semi-finals
@@ -38,5 +38,5 @@ Third-place match
 
 Final
 
-(52) 17 July  Brazil    3-2pen 0-0 aet 0-0    Italy  @ Rose Bowl, Pasadena
+(52) 17 July  Brazil    3-2pen 0-0 aet (0-0)    Italy  @ Rose Bowl, Pasadena
 

--- a/2002--south-korea-n-japan/cup_finals.txt
+++ b/2002--south-korea-n-japan/cup_finals.txt
@@ -8,14 +8,14 @@ Round of 16
 (49) 15 June   Germany    1-0    Paraguay   @ Jeju World Cup Stadium, Jeju
 (50) 15 June   Denmark    0-3    England    @ Niigata Stadium, Niigata
 
-(51) 16 June   Sweden    1-2 aet 1-1  Senegal  @ Ōita Stadium, Ōita
-(52) 16 June   Spain     3-2pen 1-1aet 1-1   Ireland  @ Suwon World Cup Stadium, Suwon
+(51) 16 June   Sweden    1-2 aet (1-1)  Senegal  @ Ōita Stadium, Ōita
+(52) 16 June   Spain     3-2pen 1-1aet (1-1)   Ireland  @ Suwon World Cup Stadium, Suwon
 
 (53) 17 June   Mexico    0-2    United States  @ Jeonju World Cup Stadium, Jeonju
 (54) 17 June   Brazil    2-0    Belgium        @ Kobe Wing Stadium, Kobe
 
 (55) 18 June   Japan     0-1    Turkey         @ Miyagi Stadium, Miyagi
-(56) 18 June   South Korea    2-1aet 1-1    Italy   @ Daejeon World Cup Stadium, Daejeon
+(56) 18 June   South Korea    2-1aet (1-1)    Italy   @ Daejeon World Cup Stadium, Daejeon
 
 
 Quarter-finals
@@ -23,8 +23,8 @@ Quarter-finals
 (57) 21 June   England    1-2    Brazil    @ Shizuoka Stadium, Shizuoka
 (58) 21 June   Germany    1-0    United States   @ Munsu Cup Stadium, Ulsan
 
-(59) 22 June   Spain    3-5pen 0-0aet 0-0    South Korea  @ Gwangju World Cup Stadium, Gwangju
-(60) 22 June   Senegal    0-1aet 0-0   Turkey    @ Nagai Stadium, Osaka
+(59) 22 June   Spain    3-5pen 0-0aet (0-0)    South Korea  @ Gwangju World Cup Stadium, Gwangju
+(60) 22 June   Senegal    0-1aet (0-0)   Turkey    @ Nagai Stadium, Osaka
 
 
 Semi-finals


### PR DESCRIPTION
These commits fix https://github.com/openfootball/world-cup/issues/48

The sports database builds fine now.